### PR TITLE
Add new `types` to the account-info schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 ### Table of Contents
 
-- [Introduction](#introduction)
-- [JSON Schema](#json-schema)
-  - [Schema Specification](#schema-specification)
-- [Usage as an Account Owner](#usage-as-an-account-owner)
-  - [How does it work?](#how-does-it-work)
-  - [What do I do?](#what-do-i-do)
+- [casper-account-info-standard](#casper-account-info-standard)
+    - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [JSON Schema](#json-schema)
+    - [Schema Specification](#schema-specification)
+  - [Usage as an Account Owner](#usage-as-an-account-owner)
+    - [How does it work?](#how-does-it-work)
+    - [What do I do?](#what-do-i-do)
 
 ## Introduction
 
@@ -28,7 +30,7 @@ it using online tools such as [JsonSchemaValidator.net](https://www.jsonschemava
     - **`name`** *(string)*: The name of the entity or person that owns the Account.
     - **`description`** *(string)*: An optional description of the Owner of the Account.
     - **`type`** *(array)*: Indicates the type of entity of the owner. One Owner can have multiple types.
-        - **Items** *(string)*: Must be one of: `["validator", "exchange", "dapp", "individual", "corporation", "dao"]`.
+        - **Items** *(string)*: Must be one of: `["validator", "exchange", "dapp", "individual", "corporation", "dao", "bridge", "collectible", "custody", "defi", "explorer", "gaming", "marketplace", "nft", "onramp", "offramp", "sdk", "staking", "tool", "wallet"]`.
     - **`identity`** *(object)*: Information about the ownership of the Account.
         - **`ownership_disclosure_url`**: Link to a page outlining entity ownership and/or governance. 
         - **`casper_association_kyc_url`**: Reserved for a link to a Casper Association provided verified identity document, as applicable to Validator members of the Association.

--- a/schema.json
+++ b/schema.json
@@ -144,7 +144,21 @@
                             "dapp",
                             "individual",
                             "corporation",
-                            "dao"
+                            "dao",
+                            "bridge",
+                            "collectible",
+                            "custody",
+                            "defi",
+                            "explorer",
+                            "gaming",
+                            "marketplace",
+                            "nft",
+                            "onramp",
+                            "offramp",
+                            "sdk",
+                            "staking",
+                            "tool",
+                            "wallet"
                         ]
                     }
                 },


### PR DESCRIPTION
PR to add the following `types` to the account-info schema, to facilitate the self-certification process on the casperecosystem.io.

```bash
"bridge",
"collectible",
"custody",
"defi",
"explorer",
"gaming",
"marketplace",
"nft",
"onramp",
"offramp",
"sdk",
"staking",
"tool",
"wallet"
```